### PR TITLE
fix: remove default_nettype

### DIFF
--- a/cores/lvds/lvds_out.sv
+++ b/cores/lvds/lvds_out.sv
@@ -1,5 +1,4 @@
 // Copyright (c) 2025 Sigma Logic
-`default_nettype none
 
 module lvds_out
     import lvds_pkg::pair_t;

--- a/cores/simple_pll/simple_pll.sv
+++ b/cores/simple_pll/simple_pll.sv
@@ -1,5 +1,4 @@
 // Copyright (c) 2025 Sigma Logic
-`default_nettype none
 
 module simple_pll
     import simple_pll_pkg::pll_cfg_t;

--- a/cores/simple_pll/simple_pll_pkg.sv
+++ b/cores/simple_pll/simple_pll_pkg.sv
@@ -2,7 +2,7 @@
 
 package simple_pll_pkg;
 
-    typedef struct packed {
+    typedef struct {
         string ref_clk_mhz;
         int i_div;
         int m_div;
@@ -23,4 +23,4 @@ package simple_pll_pkg;
         logic clk_3;
     } pll_channels_t;
 
-endpackage
+endpackage : simple_pll_pkg


### PR DESCRIPTION
Gowin IDE incorrectly handles default_nettype